### PR TITLE
⚙️[Feat] NavigationVC 생성, todo와 Complete로 push 적용

### DIFF
--- a/TodoApp.xcodeproj/project.pbxproj
+++ b/TodoApp.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		BD619C4C2A83204A00BF4EF8 /* FinishedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD619C4B2A83204A00BF4EF8 /* FinishedCell.swift */; };
 		BD8E82192A7A3B7E00474438 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E82182A7A3B7E00474438 /* AppDelegate.swift */; };
 		BD8E821B2A7A3B7E00474438 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E821A2A7A3B7E00474438 /* SceneDelegate.swift */; };
-		BD8E821D2A7A3B7E00474438 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E821C2A7A3B7E00474438 /* ViewController.swift */; };
+		BD8E821D2A7A3B7E00474438 /* TodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E821C2A7A3B7E00474438 /* TodoViewController.swift */; };
 		BD8E82202A7A3B7E00474438 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD8E821E2A7A3B7E00474438 /* Main.storyboard */; };
 		BD8E82222A7A3B8000474438 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD8E82212A7A3B8000474438 /* Assets.xcassets */; };
 		BD8E82252A7A3B8000474438 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD8E82232A7A3B8000474438 /* LaunchScreen.storyboard */; };
@@ -23,6 +23,7 @@
 		BDA2D0802AA074B400D20C00 /* Todo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA2D07E2AA074B400D20C00 /* Todo+CoreDataClass.swift */; };
 		BDA2D0812AA074B400D20C00 /* Todo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA2D07F2AA074B400D20C00 /* Todo+CoreDataProperties.swift */; };
 		BDDF36F92A85C4E600668ACF /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF36F82A85C4E600668ACF /* Errors.swift */; };
+		BDE51BC12AB1998600C4B6C5 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE51BC02AB1998600C4B6C5 /* MainViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,7 +36,7 @@
 		BD8E82152A7A3B7E00474438 /* TodoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD8E82182A7A3B7E00474438 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD8E821A2A7A3B7E00474438 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		BD8E821C2A7A3B7E00474438 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		BD8E821C2A7A3B7E00474438 /* TodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BD8E821F2A7A3B7E00474438 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		BD8E82212A7A3B8000474438 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BD8E82242A7A3B8000474438 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -44,6 +45,7 @@
 		BDA2D07E2AA074B400D20C00 /* Todo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Todo+CoreDataClass.swift"; sourceTree = "<group>"; };
 		BDA2D07F2AA074B400D20C00 /* Todo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Todo+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		BDDF36F82A85C4E600668ACF /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		BDE51BC02AB1998600C4B6C5 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,7 +133,8 @@
 		BDE0F5232AA1A2890032FA8C /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				BD8E821C2A7A3B7E00474438 /* ViewController.swift */,
+				BDE51BC02AB1998600C4B6C5 /* MainViewController.swift */,
+				BD8E821C2A7A3B7E00474438 /* TodoViewController.swift */,
 				BD8E822E2A7A408A00474438 /* FinishedController.swift */,
 			);
 			path = Controller;
@@ -208,11 +211,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD8E821D2A7A3B7E00474438 /* ViewController.swift in Sources */,
+				BD8E821D2A7A3B7E00474438 /* TodoViewController.swift in Sources */,
 				BD8E822F2A7A408A00474438 /* FinishedController.swift in Sources */,
 				BD8E82192A7A3B7E00474438 /* AppDelegate.swift in Sources */,
 				BDA2D0812AA074B400D20C00 /* Todo+CoreDataProperties.swift in Sources */,
 				BD14B08F2A9F31920056BD27 /* SectionViewCell.swift in Sources */,
+				BDE51BC12AB1998600C4B6C5 /* MainViewController.swift in Sources */,
 				BD619C4C2A83204A00BF4EF8 /* FinishedCell.swift in Sources */,
 				BD8E821B2A7A3B7E00474438 /* SceneDelegate.swift in Sources */,
 				BD0C27E92A9A3D34005245A2 /* Categories.swift in Sources */,

--- a/TodoApp/Controller/FinishedController.swift
+++ b/TodoApp/Controller/FinishedController.swift
@@ -48,6 +48,10 @@ class FinishedController: UIViewController {
         
         completedTableView.reloadData()
     }
+    
+    deinit {
+        print("FinishedViewController이 화면에서 사라졌습니다.")
+    }
 }
 
 //MARK: - UITableViewDelegate

--- a/TodoApp/Controller/MainViewController.swift
+++ b/TodoApp/Controller/MainViewController.swift
@@ -1,0 +1,72 @@
+//
+//  MainViewController.swift
+//  TodoApp
+//
+//  Created by Jack Lee on 2023/09/13.
+//
+
+import UIKit
+
+class MainViewController: UIViewController {
+
+    var checkTodoButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("할일 확인하기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.tintColor = .systemBlue
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(todoButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    var checkCompletedTodo: UIButton = {
+        let button = UIButton()
+        button.setTitle("완료한 일 확인하기", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(completedTodoTapped), for: .touchUpInside)
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .red
+        setUI()
+    }
+    
+    private func setUI() {
+        view.addSubview(checkTodoButton)
+        view.addSubview(checkCompletedTodo)
+        setButton()
+    }
+    
+    private func setButton() {
+        NSLayoutConstraint.activate([
+            checkTodoButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            checkTodoButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -100),
+            checkCompletedTodo.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            checkCompletedTodo.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+    
+    @objc func todoButtonTapped() {
+        print("투두 버튼이 눌렸습니다.")
+        let viewControllerClassToCheck = TodoViewController.self
+        
+        if let existingVC = navigationController?.viewControllers.first(where: {$0.isKind(of: viewControllerClassToCheck)}) {
+            navigationController?.pushViewController(existingVC, animated: true)
+        } else {
+            let newVC = viewControllerClassToCheck.init()
+            navigationController?.pushViewController(newVC, animated: true)
+        }
+    }
+
+    
+    @objc func completedTodoTapped() {
+        print("완료 버튼이 눌렸습니다.")
+    }
+    
+    deinit {
+        print("MainViewController이 화면에서 사라졌습니다.")
+    }
+}

--- a/TodoApp/Controller/TodoViewController.swift
+++ b/TodoApp/Controller/TodoViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  TodoViewController.swift
 //  TodoApp
 //
 //  Created by Jack Lee on 2023/08/02.
@@ -8,7 +8,7 @@
 import UIKit
 import CoreData
 
-class ViewController: UIViewController {
+class TodoViewController: UIViewController {
     
     //MARK: - Outlet 및 전역 변수 정리
     let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
@@ -269,11 +269,15 @@ class ViewController: UIViewController {
     @objc func keyboardWillHide(_ notification: NSNotification) {
         updateViewWithKeyboard(notification: notification, viewBottomConstraint: self.textFieldBottomConstraint!, keyboardWillShow: false)
     }
+    
+    deinit {
+        print("TodoViewController이 화면에서 사라졌습니다.")
+    }
 }
 
 //MARK: - UITableViewDataSource
 
-extension ViewController: UITableViewDataSource {
+extension TodoViewController: UITableViewDataSource {
     
     // 카테고리 구분
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -326,7 +330,7 @@ extension ViewController: UITableViewDataSource {
 }
 
 //MARK: - UITableViewDelegate
-extension ViewController: UITableViewDelegate {
+extension TodoViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let delete = UIContextualAction(style: .destructive, title: "삭제하기") { (action, view, completionHandler) in
@@ -345,17 +349,17 @@ extension ViewController: UITableViewDelegate {
     }
 }
 
-extension ViewController: UITextFieldDelegate {
+extension TodoViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         messageTextField.resignFirstResponder()
     }
 }
 
-extension ViewController: UICollectionViewDelegate {
+extension TodoViewController: UICollectionViewDelegate {
     
 }
 
-extension ViewController: UICollectionViewDataSource {
+extension TodoViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return Categories.allCases.count
     }

--- a/TodoApp/SceneDelegate.swift
+++ b/TodoApp/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window?.windowScene = windowScene
         window?.makeKeyAndVisible()
-        let controller = ViewController()
+        let controller = MainViewController()
         let navController = UINavigationController(rootViewController: controller)
         window?.rootViewController = navController
     }


### PR DESCRIPTION
1. 프로젝트 요청사항에 맞도록 profilePage를 생성하기 전, todo / complete을 선택할 수 있는 페이지 생성
2. NavigationController에서 push 이전, 이전에 생성된 VC인지 확인 이후 메모리 상 존재할 경우 재활용할 수 있도록 코드 추가